### PR TITLE
Adding docker building and running of elastichoney

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.3-onbuild
+
+RUN go build -o elastichoney
+
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Usage of elastichoney:
 
 See the [blog post](http://jordan-wright.github.io/blog/2015/03/23/introducing-elastichoney-an-elasticsearch-honeypot/) for more details.
 
+### Docker
+If you would like to compile and run elastichoney using [Docker](https://github.com/docker/docker) and [Docker Compose](https://github.com/docker/compose),
+you can do so by running:
+```
+mkdir logs
+docker-compose build
+docker-compose up
+```
+
 ### License
 ```
 The MIT License (MIT)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+elastichoney:
+    build: ./
+    volumes:
+        - ./logs:/go/src/app/logs/
+    ports:
+        - 9200:9200
+    command: ./elastichoney -config="config.json" -log="logs/elastichoney.log" -verbose=true


### PR DESCRIPTION
Not sure if this is something you would want, but it's all packaged nicely if you would like to make it available. If you want to up your version of go, just change the `FROM` line in the Dockerfile to something from go's [docker repository](https://registry.hub.docker.com/_/golang/)
